### PR TITLE
Add continous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "3.5"
+  - "3.6"
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ python:
   - "3.6"
 install: pip install tox-travis
 script: tox
+addons:
+  postgresql: "9.4"

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,12 @@
 ATOL
 ====
 
-Application for connecting online cashbox ATOL
-Only 1 purchase is supported in receipt (1 product)
+Application for integrating Django and  https://online.atol.ru/
 
-
+Important limitations:
+    * Python 3.5+ 
+    * PostgreSQL ≥ 9.4 (JSONB field)
+    * only 1 purchase is supported in receipt (1 product)
 
 Quick start
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,11 @@
 #!/usr/bin/env python
 import os
 import re
-import sys
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 def get_version(package):
@@ -68,11 +47,11 @@ test_requirements = [
 setup(
     name='django-atol',
     version=get_version('atol'),
-    description='Integration with ATOL',
+    description='Django integration with ATOL online',
     long_description=readme + '\n\n' + history,
     author='MyBook',
     author_email='dev@mybook.ru',
-    url='https://github.com/MyBook/atol',
+    url='https://github.com/MyBook/django-atol',
     packages=[
         'atol',
         'atol.migrations'
@@ -80,6 +59,7 @@ setup(
     package_dir={'atol': 'atol'},
     include_package_data=True,
     install_requires=requirements,
+    setup_requires=['pytest-runner>=2.0,<3dev'],
     license='BSD',
     zip_safe=False,
     keywords='atol',
@@ -89,11 +69,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    cmdclass={'test': PyTest},
 )

--- a/tests/test_app/__init__.py
+++ b/tests/test_app/__init__.py
@@ -1,1 +1,1 @@
-from .celery import app
+from .celery import app  # noqa

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -52,9 +52,7 @@ TEMPLATES = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'atol',
-        'USER': 'atol',
-        'PASSWORD': 'hSFzCPZYzyhF88Up',
+        'NAME': 'atol'
     }
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,13 @@ setenv =
 commands = python setup.py test --addopts "--cov=atol --cov-append"
 usedevelop = true
 
-
 [testenv:flake8]
 deps = flake8
 commands = flake8 atol tests --ignore=F403 --max-line-length=120
 
 [tool:pytest]
 addopts = --tb=native
+
+[travis]
+python =
+  3.6: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py35, py36, flake8
+
+[testenv]
+deps = coverage
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/litresapi
+commands = python setup.py test --addopts "--cov=atol --cov-append"
+usedevelop = true
+
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 atol tests --ignore=F403 --max-line-length=120
+
+[tool:pytest]
+addopts = --tb=native

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,5 @@ addopts = --tb=native
 
 [travis]
 python =
-  3.6: flake8
+  3.5: py35
+  3.6: py36, flake8

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = py35, py36, flake8
 
 [testenv]
 deps = coverage
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/litresapi
 commands = python setup.py test --addopts "--cov=atol --cov-append"
 usedevelop = true
 


### PR DESCRIPTION
- support only python 3.5+ for simplicity
- drop password for postgres db so that pytest can create db
- use pytest-runner instead of legacy PyTest(TestCommand)
- test for flake8
- travis CI support