### PR TITLE
atol:core:AtolAPI: add possibility for customizing base_url

### DIFF
--- a/atol/core.py
+++ b/atol/core.py
@@ -15,7 +15,7 @@ ReceiptReport = namedtuple('ReceiptReport', ['uuid', 'data'])
 
 
 class AtolAPI(object):
-    base_url = 'https://online.atol.ru/possystem/v3'
+    base_url = getattr(settings, 'RECEIPTS_ATOL_BASE_URL', 'https://online.atol.ru/possystem/v3')
     request_timeout = 5
 
     def _obtain_new_token(self):

--- a/atol/core.py
+++ b/atol/core.py
@@ -15,8 +15,10 @@ ReceiptReport = namedtuple('ReceiptReport', ['uuid', 'data'])
 
 
 class AtolAPI(object):
-    base_url = getattr(settings, 'RECEIPTS_ATOL_BASE_URL', 'https://online.atol.ru/possystem/v3')
     request_timeout = 5
+
+    def __init__(self):
+        self.base_url = getattr(settings, 'RECEIPTS_ATOL_BASE_URL', None) or 'https://online.atol.ru/possystem/v3'
 
     def _obtain_new_token(self):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,7 +267,7 @@ def test_atol_report_unrecoverable_errors(status, params, set_atol_token):
 
 def test_atol_api_base_url():
     """
-    Проверяем base_url в случае если RECEIPTS_ATOL_BASE_URL не указан в settings
+    We Check base_url in case that RECEIPTS_ATOL_BASE_URL is not specified in settings
     """
     assert AtolAPI().base_url == 'https://online.atol.ru/possystem/v3'
 
@@ -279,9 +279,9 @@ def test_atol_api_base_url():
 ])
 def test_atol_api_base_url_customizing(settings_url, api_base_url):
     """
-    Проверяем base_url в случае указания различных конфигураций RECEIPTS_ATOL_BASE_URL в settings
-    :param settings_url: url в settings
-    :param api_base_url: url, который должен быть в AtolAPI
+    We check base_url in case of specifying RECEIPTS_ATOL_BASE_URL as different values in settings
+    :param settings_url: url in settings
+    :param api_base_url: url, which must be in AtolAPI
     """
     with override_settings(RECEIPTS_ATOL_BASE_URL=settings_url):
         assert AtolAPI().base_url == api_base_url

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from uuid import uuid4
 import responses
 import pytest
+from django.test import override_settings
 
 from atol.core import AtolAPI
 from atol.exceptions import AtolRecoverableError, AtolUnrecoverableError
@@ -262,3 +263,25 @@ def test_atol_report_unrecoverable_errors(status, params, set_atol_token):
 
     with pytest.raises(AtolUnrecoverableError):
         atol.report(payment_uuid)
+
+
+def test_atol_api_base_url():
+    """
+    Проверяем base_url в случае если RECEIPTS_ATOL_BASE_URL не указан в settings
+    """
+    assert AtolAPI().base_url == 'https://online.atol.ru/possystem/v3'
+
+
+@pytest.mark.parametrize('settings_url, api_base_url', [
+    ('test_url', 'test_url'),
+    ('', 'https://online.atol.ru/possystem/v3'),
+    (None, 'https://online.atol.ru/possystem/v3')
+])
+def test_atol_api_base_url_customizing(settings_url, api_base_url):
+    """
+    Проверяем base_url в случае указания различных конфигураций RECEIPTS_ATOL_BASE_URL в settings
+    :param settings_url: url в settings
+    :param api_base_url: url, который должен быть в AtolAPI
+    """
+    with override_settings(RECEIPTS_ATOL_BASE_URL=settings_url):
+        assert AtolAPI().base_url == api_base_url


### PR DESCRIPTION
Добавил возможность указать базовую урлу для апи атола.
Зачем?
Потому что тестовый акканут должен ходить в другой эндпоинт

И как правильно сделать новую версию? Через релиз или просто апнуть версию пакета?