### PR TITLE
Add Django 4.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 dist: bionic
-sudo: false
 language: python
 python:
   - "3.5"
@@ -25,7 +25,7 @@ notifications:
   email: false
 deploy:
   - provider: pypi
-    user: mybook
+    username: mybook
     distributions: sdist bdist_wheel
     password:
       secure: jiMI/Rzyi/rb0VG7dYy7Lnt/99Yp2RecM0LT2SwMm8oZFpOoM1HDAOLjt2r6+IW1VnmJCdI3UFvU7MgPwYxg6DN++cj1Ag5IYqnmQAZL2cKWy1L7mGJ5/CkvHsr00OHmZhPCzPIavqv7OxIxAt5tqohCBYbJkJJh/1s26wqlDIBiMO9gQZZUjTALUGMLq0bRf44QC9KRWJkEg4uoRCUFzpAF5A2M5TBTEjOLID+DLHKdXT1YVSrD0wWbIxzYE3tg7L+fJhvUOTxHjsz+KoE7//LaqxXoQ6QjQH3Bwv2mm71VXhA906y9Pfkf27fpfpzHiSYgRZ1tnga4Ktbi9eEe0y+u5c8GbJxtyilFiulhWIPgrMrDcZxXCDvyKObZ5t9sRoNSFON2gXru8Qq0NuxGm65WFVB9aat7BNMNW115pyAAvL7sJmR+R+Vyf1sRBKgxgVkuiLaUu2MD+9wQCMsDVRVNrXYpXYMs1oJTr2eBOFP6z2LOvVwPclO/OTWV8HUdt8T6wKgqvfaLrwS+HYzmZ3vzGlklIKfiqt2LcZ5VNKRwNyplnJYP7enKtgOIfKdlSignko6KOY09U9naxOS0G0mFguqQBJl9UP2DbTGGfPF4TPrLh4702n4H5fw9gexIsPubmm8YhHGcQQ8cFFHDaMXyKcxLOUb4xxhQeXI3jBY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
     - postgresql-client-11
 before_install:
   - pip install codecov
-  - cat /etc/postgresql/11/main/pg_hba.conf
 after_success:
   - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
     - postgresql-client-11
 before_install:
   - pip install codecov
+  - cat /etc/postgresql/11/main/pg_hba.conf
 after_success:
   - codecov
 
@@ -34,5 +35,5 @@ deploy:
 
 env:
   global:
-  - PGPORT=5433
-  - PGUSER=travis
+  - PGPORT=5432
+  - PGUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 install: pip install tox-travis
 script: tox
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ python:
 install: pip install tox-travis
 script: tox
 addons:
-  postgresql: "9.4"
+  postgresql: "11"
+  apt:
+    packages:
+    - postgresql-11
+    - postgresql-client-11
 before_install:
   - pip install codecov
 after_success:
@@ -27,3 +31,8 @@ deploy:
       secure: jiMI/Rzyi/rb0VG7dYy7Lnt/99Yp2RecM0LT2SwMm8oZFpOoM1HDAOLjt2r6+IW1VnmJCdI3UFvU7MgPwYxg6DN++cj1Ag5IYqnmQAZL2cKWy1L7mGJ5/CkvHsr00OHmZhPCzPIavqv7OxIxAt5tqohCBYbJkJJh/1s26wqlDIBiMO9gQZZUjTALUGMLq0bRf44QC9KRWJkEg4uoRCUFzpAF5A2M5TBTEjOLID+DLHKdXT1YVSrD0wWbIxzYE3tg7L+fJhvUOTxHjsz+KoE7//LaqxXoQ6QjQH3Bwv2mm71VXhA906y9Pfkf27fpfpzHiSYgRZ1tnga4Ktbi9eEe0y+u5c8GbJxtyilFiulhWIPgrMrDcZxXCDvyKObZ5t9sRoNSFON2gXru8Qq0NuxGm65WFVB9aat7BNMNW115pyAAvL7sJmR+R+Vyf1sRBKgxgVkuiLaUu2MD+9wQCMsDVRVNrXYpXYMs1oJTr2eBOFP6z2LOvVwPclO/OTWV8HUdt8T6wKgqvfaLrwS+HYzmZ3vzGlklIKfiqt2LcZ5VNKRwNyplnJYP7enKtgOIfKdlSignko6KOY09U9naxOS0G0mFguqQBJl9UP2DbTGGfPF4TPrLh4702n4H5fw9gexIsPubmm8YhHGcQQ8cFFHDaMXyKcxLOUb4xxhQeXI3jBY=
     on:
       tags: true
+
+env:
+  global:
+  - PGPORT=5433
+  - PGUSER=travis

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+1.4.0 (2022-08-17)
+------------------
+* Add Django 4.0 support
+* Add Python ≥ 3.7 and Django ≥ 3.0 CI tests
+* Upgrade CI Linux dist to Ubuntu 18.04 (Bionic) for Python 3.10 tests
+* Upgrade CI Postgres version to 11 for Django 4.x tests
+
 1.3.4 (2021-10-05)
 ------------------
 * Fix bug with payment_method parameter

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ ATOL
 
 Application for integrating Django and  https://online.atol.ru/
 
-.. image:: https://img.shields.io/badge/python-3.5,%203.6-blue.svg
+.. image:: https://img.shields.io/badge/python-3.5,%203.6,%203.7,%203.8,%203.9,%203.10-blue.svg
     :target: https://pypi.python.org/pypi/django-atol/
 .. image:: https://travis-ci.org/MyBook/django-atol.svg?branch=master
     :target: https://travis-ci.org/MyBook/django-atol

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Important limitations:
 
     * Python 3.5+
     * Support Django 1.11+
-    * PostgreSQL ≥ 9.4 (JSONB field)
+    * PostgreSQL ≥ 9.4 (JSONB field) (PostgreSQL ≥ 11 for Django 4.0)
     * only 1 purchase is supported in receipt (1 product)
     * only v3 protocol version is supported
 

--- a/atol/core.py
+++ b/atol/core.py
@@ -5,7 +5,7 @@ from dateutil.parser import parse as parse_date
 
 from django.conf import settings
 from django.core.cache import cache
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from model_utils import Choices
 
 from atol import exceptions

--- a/atol/models.py
+++ b/atol/models.py
@@ -6,7 +6,7 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models, transaction
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 try:
     from django.urls import reverse

--- a/atol/signals.py
+++ b/atol/signals.py
@@ -16,6 +16,6 @@ receipt_received:
 """
 from django.dispatch import Signal
 
-receipt_initiated = Signal(providing_args=['receipt'])
-receipt_failed = Signal(providing_args=['receipt'])
-receipt_received = Signal(providing_args=['receipt'])
+receipt_initiated = Signal()
+receipt_failed = Signal()
+receipt_received = Signal()

--- a/atol/views.py
+++ b/atol/views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseNotFound
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_bytes
 from django.views.generic import RedirectView
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from atol.models import Receipt
 from atol.exceptions import MissingReceipt

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -53,8 +53,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'atol',
-        'PORT': os.environ('PGPORT'),
-        'USER': os.environ('PGUSER'),
+        'PORT': os.environ['PGPORT'],
+        'USER': os.environ['PGUSER'],
     }
 }
 

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -52,7 +52,9 @@ TEMPLATES = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'atol'
+        'NAME': 'atol',
+        'PORT': os.environ('PGPORT'),
+        'USER': os.environ('PGUSER'),
     }
 }
 

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import re_path
 from atol.views import ReceiptView
 
 urlpatterns = [
-    url(r'^r/(?P<short_uuid>[\w]+)/$', ReceiptView.as_view(), name='receipt'),
+    re_path(r'^r/(?P<short_uuid>[\w]+)/$', ReceiptView.as_view(), name='receipt'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ deps =
     coverage
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     -rrequirements/requirements-testing.txt
 commands =
     python setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}-django{111,20,30,31,32}, py{36,37}-django{30,31,32}, py{38,39,310}-django{30,31,32,40,41} flake8
+envlist = py{35}-django{111,20}, py{36}-django{111,20,30,31,32}, py{36,37}-django{30,31,32}, py{38,39,310}-django{30,31,32,40,41}, flake8
 
 [testenv]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}-django{111,20}, flake8
+envlist = py{35,36,37,38,39,310}-django{111,20,30,31,32,40,41}, flake8
 
 [testenv]
 deps = 
@@ -28,8 +28,17 @@ addopts = --tb=native
 python =
   3.5: py35
   3.6: py36, flake8
+  3.7: py37, flake8
+  3.8: py38, flake8
+  3.9: py39, flake8
+  3.10: py310, flake8
 
 [travis:env]
 DJANGO =
   1.11: django111
   2.0: django20
+  3.0: django30
+  3.1: django31
+  3.2: django32
+  4.0: django40
+  4.1: django41

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = py{35}-django{111,20}, py{36}-django{111,20,30,31,32}, py{36,37}-django{30,31,32}, py{38,39,310}-django{30,31,32,40,41}, flake8
+envlist =
+    py{35}-django{111,20}
+    py{36}-django{111,20,30,31,32}
+    py{36,37}-django{30,31,32}
+    py{38,39,310}-django{30,31,32,40,41}
+    flake8
 
 [testenv]
 deps = 
@@ -16,6 +21,7 @@ commands =
     python setup.py install
     py.test --cov=atol --cov-append
 usedevelop = true
+passenv = PGPORT-PGUSER
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,9 @@ commands =
     python setup.py install
     py.test --cov=atol --cov-append
 usedevelop = true
-passenv = PGPORT-PGUSER
+passenv =
+    PGPORT
+    PGUSER
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310}-django{111,20,30,31,32,40,41}, flake8
+envlist = py{35,36}-django{111,20,30,31,32}, py{36,37}-django{30,31,32}, py{38,39,310}-django{30,31,32,40,41} flake8
 
 [testenv]
 deps = 


### PR DESCRIPTION
Django 4.0 removes [deprecated features](https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0):

- `django.utils.translation.ugettext_lazy()`
- `providing_args` argument for `django.dispatch.Signal`
- `django.conf.urls.url()`