### PR TITLE
Fix Travis badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Application for integrating Django and  https://online.atol.ru/
 
 .. image:: https://img.shields.io/badge/python-3.5,%203.6,%203.7,%203.8,%203.9,%203.10-blue.svg
     :target: https://pypi.python.org/pypi/django-atol/
-.. image:: https://travis-ci.org/MyBook/django-atol.svg?branch=master
-    :target: https://travis-ci.org/MyBook/django-atol
+.. image:: https://travis-ci.com/MyBook/django-atol.svg?branch=master
+    :target: https://travis-ci.com/MyBook/django-atol
 .. image:: https://codecov.io/gh/MyBook/django-atol/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/MyBook/django-atol
 .. image:: https://img.shields.io/badge/docs-v3-yellow.svg


### PR DESCRIPTION
travis-ci.org moved to travis-ci.com